### PR TITLE
Correct month representation for June

### DIFF
--- a/Tile.cpp
+++ b/Tile.cpp
@@ -38,7 +38,7 @@ namespace Nessie {
     // The negative numbers are placeholders for the monthes
     // The positive numbers specify the position of the given day on the table
     const TableLayout MainTable = {
-        {  -1,  -2,  -3,  -4,  -5,  -7,   0 },
+        {  -1,  -2,  -3,  -4,  -5,  -6,   0 },
         {  -7,  -8,  -9, -10, -11, -12,   0 },
         {  +1,  +2,  +3,  +4,  +5,  +6,  +7 },
         {  +8,  +9, +10, +11, +12, +13, +14 },


### PR DESCRIPTION
June in Table was left as -7 instead of -6